### PR TITLE
Add alt text descriptions

### DIFF
--- a/src/components/Work/PortfolioItems.jsx
+++ b/src/components/Work/PortfolioItems.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 const PortfolioItems = ({item}) => {
   return (
     <a href={item.url} className="portfolio__card" target="_blank" rel="noopener noreferrer" key={item.id}>
-      <img src={item.image} alt="" className="portfolio__img" />
+      <img src={item.image} alt={`Screenshot of ${item.title} project`} className="portfolio__img" />
       <h3 className="portfolio__title">{item.title}</h3>
       <div className="portfolio__button">
         More Info <i className="bx bx-right-arrow-alt portfolio__button-icon"></i>

--- a/src/components/about/about.jsx
+++ b/src/components/about/about.jsx
@@ -11,7 +11,7 @@ const about = () => {
       <span className="section__subtitle">My Introduction</span>
 
       <div className="about__container container grid">
-        <img src={AboutImg} alt="" className="about__img" />
+        <img src={AboutImg} alt="Sebastian's profile picture" className="about__img" />
         <div className="about__data">
           <Info />
 


### PR DESCRIPTION
## Summary
- add descriptive `alt` text for about page image
- add descriptive `alt` text for portfolio item images

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c68e194ec8322a07d9baebc41289c