### PR TITLE
Add load more functionality to portfolio

### DIFF
--- a/src/components/Work/Portfolio.jsx
+++ b/src/components/Work/Portfolio.jsx
@@ -8,6 +8,7 @@ const Portfolio = () => {
   const [item, setItem] = useState({name: 'All' });
   const [projects, setProjects] = useState([]);
   const [active, setActive] = useState(0);
+  const [visibleCount, setVisibleCount] = useState(6);
 
   useEffect(() => {
     if (item.name === 'All') {
@@ -37,12 +38,17 @@ const Portfolio = () => {
       </div>
 
       <div className="portfolio__container container grid">
-        {projects.map((item) => {
+        {projects.slice(0, visibleCount).map((item) => {
           return (
             <PortfolioItems item = {item} key = {item.id} />
           )
         })}
       </div>
+      {visibleCount < projects.length && (
+        <button className="button" onClick={() => setVisibleCount(visibleCount + 3)}>
+          Load More
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- limit portfolio items with `visibleCount`
- show more items with Load More button

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688c6df9d9508322b059215d9e297bc4