### PR TITLE
Add company work section

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Home from './components/Home/Home';
 import About from  './components/about/about';
 import Skills from './components/skills/Skills';
 import Work from './components/Work/Work';
+import CompanyWork from './components/CompanyWork/CompanyWork';
 import Studies from './components/Studies/Studies';
 import Contact from './components/Contact/Contact';
 import Footer from './components/Footer/Footer';
@@ -19,6 +20,7 @@ const App = () => {
       <About />
       <Skills />
       <Work />
+      <CompanyWork />
       <Studies />
       <Contact />
     </main>

--- a/src/components/CompanyWork/CompanyPortfolio.jsx
+++ b/src/components/CompanyWork/CompanyPortfolio.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import PortfolioItems from '../Work/PortfolioItems';
+import { companyProjectsData, companyNav } from './Data';
+
+const CompanyPortfolio = () => {
+  const [item, setItem] = useState({ name: 'All' });
+  const [projects, setProjects] = useState([]);
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    if (item.name === 'All') {
+      setProjects(companyProjectsData);
+    } else {
+      const newProjects = companyProjectsData.filter((project) => project.category === item.name);
+      setProjects(newProjects);
+    }
+  }, [item]);
+
+  const handleClick = (e, index) => {
+    setItem({ name: e.target.textContent });
+    setActive(index);
+  };
+
+  return (
+    <div>
+      <div className="portfolio__filters">
+        {companyNav.map((item, index) => (
+          <span
+            onClick={(e) => handleClick(e, index)}
+            className={`${active === index ? 'active-work' : ''} portfolio__item`}
+            key={index}
+          >
+            {item.name}
+          </span>
+        ))}
+      </div>
+
+      <div className="portfolio__container container grid">
+        {projects.map((item) => (
+          <PortfolioItems item={item} key={item.id} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CompanyPortfolio;

--- a/src/components/CompanyWork/CompanyWork.jsx
+++ b/src/components/CompanyWork/CompanyWork.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import CompanyPortfolio from './CompanyPortfolio';
+import '../Work/work.css';
+
+const CompanyWork = () => {
+  return (
+    <section className="work section" id="company-work">
+      <h2 className="section__title">Professional Work</h2>
+      <span className="section__subtitle">Company projects</span>
+
+      <CompanyPortfolio />
+    </section>
+  );
+};
+
+export default CompanyWork;

--- a/src/components/CompanyWork/Data.jsx
+++ b/src/components/CompanyWork/Data.jsx
@@ -1,0 +1,42 @@
+import BankHero from '../../assets/BankHero.png';
+import Parche1 from '../../assets/Parche1.png';
+import Solar1 from '../../assets/Solar1.png';
+
+export const companyProjectsData = [
+  {
+    id: 1,
+    image: BankHero,
+    title: 'Website Redesign',
+    category: 'Company A',
+    url: 'https://example.com/company-a-project'
+  },
+  {
+    id: 2,
+    image: Parche1,
+    title: 'Mobile App',
+    category: 'Company B',
+    url: 'https://example.com/company-b-project'
+  },
+  {
+    id: 3,
+    image: Solar1,
+    title: 'Dashboard UI',
+    category: 'Company C',
+    url: 'https://example.com/company-c-project'
+  }
+];
+
+export const companyNav = [
+  {
+    name: 'All'
+  },
+  {
+    name: 'Company A'
+  },
+  {
+    name: 'Company B'
+  },
+  {
+    name: 'Company C'
+  }
+];


### PR DESCRIPTION
## Summary
- add company project data with filter navigation
- implement CompanyPortfolio for filtering company projects
- create CompanyWork section rendering CompanyPortfolio
- render CompanyWork in App

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c7228bc00832281fba42fc136154c