### PR TITLE
Fix missing alt text

### DIFF
--- a/src/components/Work/PortfolioItems.jsx
+++ b/src/components/Work/PortfolioItems.jsx
@@ -2,8 +2,8 @@ import React from 'react'
 
 const PortfolioItems = ({item}) => {
   return (
-    <a href={item.url} className="portfolio__card" target="_blank" rel="noopener noreferrer" key={item.id}>
-      <img src={item.image} alt="" className="portfolio__img" />
+      <a href={item.url} className="portfolio__card" target="_blank" rel="noopener noreferrer" key={item.id}>
+        <img src={item.image} alt={item.title} className="portfolio__img" />
       <h3 className="portfolio__title">{item.title}</h3>
       <div className="portfolio__button">
         More Info <i className="bx bx-right-arrow-alt portfolio__button-icon"></i>

--- a/src/components/about/about.jsx
+++ b/src/components/about/about.jsx
@@ -11,7 +11,7 @@ const about = () => {
       <span className="section__subtitle">My Introduction</span>
 
       <div className="about__container container grid">
-        <img src={AboutImg} alt="" className="about__img" />
+        <img src={AboutImg} alt="Profile picture" className="about__img" />
         <div className="about__data">
           <Info />
 


### PR DESCRIPTION
## Summary
- add missing alt text to the About image
- apply each portfolio title as the alt text for project images

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688c722b38fc8322ad4083c74cfa9aeb