### PR TITLE
fix: remove redundant about image alt attribute

### DIFF
--- a/src/components/about/about.jsx
+++ b/src/components/about/about.jsx
@@ -11,7 +11,7 @@ const about = () => {
       <span className="section__subtitle">My Introduction</span>
 
       <div className="about__container container grid">
-        <img src={AboutImg} alt="Sebastian's profile picture" className="about__img" />
+        <img src={AboutImg} alt="Sebastian" className="about__img" />
         <div className="about__data">
           <Info />
 


### PR DESCRIPTION
## Summary
- simplify about image alt text

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e707755208322af673b5c1eddede9