### PR TITLE
Add pagination to company portfolio

### DIFF
--- a/src/components/CompanyWork/CompanyPortfolio.jsx
+++ b/src/components/CompanyWork/CompanyPortfolio.jsx
@@ -1,13 +1,55 @@
-import React from 'react';
+import React, { useState } from 'react';
 import MerchantCard from './MerchantCard';
 import { merchantsData } from './Data';
 
-const CompanyPortfolio = () => (
-  <div className="portfolio__container container grid">
-    {merchantsData.map((merchant) => (
-      <MerchantCard key={merchant.id} merchant={merchant} />
-    ))}
-  </div>
-);
+const ITEMS_PER_PAGE = 6;
+
+const CompanyPortfolio = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const totalPages = Math.ceil(merchantsData.length / ITEMS_PER_PAGE);
+
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const currentMerchants = merchantsData.slice(
+    startIndex,
+    startIndex + ITEMS_PER_PAGE
+  );
+
+  const handlePrev = () => {
+    setCurrentPage((prev) => Math.max(prev - 1, 1));
+  };
+
+  const handleNext = () => {
+    setCurrentPage((prev) => Math.min(prev + 1, totalPages));
+  };
+
+  return (
+    <>
+      <div className="portfolio__container container grid">
+        {currentMerchants.map((merchant) => (
+          <MerchantCard key={merchant.id} merchant={merchant} />
+        ))}
+      </div>
+      <div className="portfolio__pagination">
+        <button
+          className="portfolio__item"
+          onClick={handlePrev}
+          disabled={currentPage === 1}
+        >
+          Previous
+        </button>
+        <span className="portfolio__page-indicator">
+          {currentPage} / {totalPages}
+        </span>
+        <button
+          className="portfolio__item"
+          onClick={handleNext}
+          disabled={currentPage === totalPages}
+        >
+          Next
+        </button>
+      </div>
+    </>
+  );
+};
 
 export default CompanyPortfolio;

--- a/src/components/Work/work.css
+++ b/src/components/Work/work.css
@@ -16,8 +16,7 @@
 }
 
 .portfolio__item:hover {
-    background-color: var(--title-color-dark);
-    color: var(--container-color);
+    color: var(--title-color-dark);
 }
 
 
@@ -102,6 +101,29 @@
     transform: translateX(0.25rem);
 }
 
+
+/* Pagination */
+.portfolio__pagination {
+    margin-top: var(--mb-2);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    column-gap: 1rem;
+}
+
+.portfolio__pagination .portfolio__item {
+    background: none;
+    border: none;
+}
+
+.portfolio__pagination button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.portfolio__page-indicator {
+    font-weight: var(--font-bold);
+}
 
 /* Active */
 


### PR DESCRIPTION
## Summary
- paginate CompanyPortfolio with React state
- show only six merchants per page with prev/next controls
- style pagination controls to match existing portfolio
- refine hover color for portfolio items

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688fbeb173c48322b3bb19adc1e68f3d